### PR TITLE
Popup menu items by letter, and exception handler

### DIFF
--- a/src/lib/configmanager.py
+++ b/src/lib/configmanager.py
@@ -56,6 +56,9 @@ COLUMN_WIDTHS = "columnWidths"
 SHOW_TOOLBAR = "showToolbar"
 NOTIFICATION_ICON = "notificationIcon"
 WORKAROUND_APP_REGEX = "workAroundApps"
+# Added by Trey Blancher (ectospasm) 2015-09-16
+TRIGGER_BY_INITIAL = "triggerItemByInitial"
+
 SCRIPT_GLOBALS = "scriptGlobals"
 
 # TODO - Future functionality
@@ -181,6 +184,7 @@ class ConfigManager:
                 SHOW_TOOLBAR : True,
                 NOTIFICATION_ICON : common.ICON_FILE_NOTIFICATION,
                 WORKAROUND_APP_REGEX : ".*VirtualBox.*|krdc.Krdc",
+                TRIGGER_BY_INITIAL : False,
                 # TODO - Future functionality
                 #TRACK_RECENT_ENTRY : True,
                 #RECENT_ENTRY_COUNT : 5,

--- a/src/lib/gtkui/data/settingsdialog.xml
+++ b/src/lib/gtkui/data/settingsdialog.xml
@@ -236,6 +236,22 @@
                                     <property name="position">1</property>
                                   </packing>
                                 </child>
+                                <child>
+                                 <object class="GtkCheckButton" id="triggerItemByInitial">
+                                    <property name="label" translatable="yes">Trigger menu item by first initial</property>
+                                    <property name="use_action_appearance">False</property>
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">True</property>
+                                    <property name="receives_default">False</property>
+                                    <property name="use_action_appearance">False</property>
+                                    <property name="draw_indicator">True</property>
+                                  </object>                                                                                                                                                                                                  
+                                  <packing>                                                                                                                                                                                                  
+                                    <property name="expand">True</property>                                                                                                                                                                  
+                                    <property name="fill">True</property>                                                                                                                                                                    
+                                    <property name="position">2</property>                                                                                                                                                                   
+                                  </packing>                                
+                                </child>
                               </object>
                             </child>
                           </object>

--- a/src/lib/gtkui/popupmenu.py
+++ b/src/lib/gtkui/popupmenu.py
@@ -43,6 +43,14 @@ class PopupMenu(Gtk.Menu):
             folders.sort(key=lambda obj: str(obj))
             items.sort(key=lambda obj: str(obj))      
         
+        if ConfigManager.SETTINGS[TRIGGER_BY_INITIAL]:
+            _logger.debug("Triggering menu item by first initial")
+            self.triggerInitial = 1
+        else:
+            _logger.debug("Triggering menu item by position in list")
+            self.triggerInitial = 0
+
+
         if len(folders) == 1 and len(items) == 0 and onDesktop:
             # Only one folder - create menu with just its folders and items
             for folder in folders[0].folders:
@@ -73,7 +81,10 @@ class PopupMenu(Gtk.Menu):
         
     def __getMnemonic(self, desc, onDesktop):
         if 1 < 10 and '_' not in desc and onDesktop:
-            ret = "_%d - %s" % (self.__i, desc)
+            if self.triggerInitial:
+                ret = "%s" % (desc)
+            else:
+                ret = "_%d - %s" % (self.__i, desc)
             self.__i += 1
             return ret
         else:

--- a/src/lib/gtkui/settingsdialog.py
+++ b/src/lib/gtkui/settingsdialog.py
@@ -54,6 +54,8 @@ class SettingsDialog:
         self.allowKbNavCheckbox = builder.get_object("allowKbNavCheckbox")
         self.allowKbNavCheckbox.hide()
         self.sortByUsageCheckbox = builder.get_object("sortByUsageCheckbox")
+        # Added by Trey Blancher (ectospasm) 2015-09-16
+        self.triggerItemByInitial = builder.get_object("triggerItemByInitial")
         self.enableUndoCheckbox = builder.get_object("enableUndoCheckbox")
         
         self.iconStyleCombo = Gtk.ComboBoxText.new()
@@ -71,6 +73,8 @@ class SettingsDialog:
         self.promptToSaveCheckbox.set_active(ConfigManager.SETTINGS[PROMPT_TO_SAVE])
         self.showTrayCheckbox.set_active(ConfigManager.SETTINGS[SHOW_TRAY_ICON])
         #self.allowKbNavCheckbox.set_active(ConfigManager.SETTINGS[MENU_TAKES_FOCUS])
+        # Added by Trey Blancher (ectospasm) 2015-09-16
+        self.triggerItemByInitial.set_active(ConfigManager.SETTINGS[TRIGGER_BY_INITIAL])
         self.sortByUsageCheckbox.set_active(ConfigManager.SETTINGS[SORT_BY_USAGE_COUNT])
         self.enableUndoCheckbox.set_active(ConfigManager.SETTINGS[UNDO_USING_BACKSPACE])
         
@@ -119,6 +123,8 @@ class SettingsDialog:
         ConfigManager.SETTINGS[SHOW_TRAY_ICON] = self.showTrayCheckbox.get_active()
         #ConfigManager.SETTINGS[MENU_TAKES_FOCUS] = self.allowKbNavCheckbox.get_active()
         ConfigManager.SETTINGS[SORT_BY_USAGE_COUNT] = self.sortByUsageCheckbox.get_active()
+        # Added by Trey Blancher (ectospasm) 2015-09-16
+        ConfigManager.SETTINGS[TRIGGER_BY_INITIAL] = self.triggerItemByInitial.get_active()
         ConfigManager.SETTINGS[UNDO_USING_BACKSPACE] = self.enableUndoCheckbox.get_active()
         ConfigManager.SETTINGS[NOTIFICATION_ICON] = ICON_NAME_MAP[self.iconStyleCombo.get_active_text()]
         

--- a/src/lib/interface.py
+++ b/src/lib/interface.py
@@ -953,9 +953,8 @@ class XInterfaceBase(threading.Thread):
         except error.BadWindow as e:#TODO_PY3
             print(__name__, repr(e))
             return ""
-        # except:
-        #     return ""
-
+        except:  # Default handler
+            return ""
 
     def __getWinTitle(self, windowvar, traverse):
         atom = windowvar.get_property(self.__VisibleNameAtom, 0, 0, 255)


### PR DESCRIPTION
I added an option to trigger popup menu items by a letter, rather than their number in the list.  I added the option to the preferences dialog, so it can be enabled or disabled at will.  If it is enabled, the letter to trigger a menu item comes from the item name itself.  Prefix the desired letter of the phrase or script name with an underscore ('_'), and AutoKey will execute that item when the letter is pressed (obviously only if that popup menu is visible).  I got inspiration from OS X's Keyboard Maestro, which does something similar with it's "conflict resolution dialogs," its fancy name for a popup menu.  This feature has only been added to the GTK version, I haven't investigated whether it would be just as simple to update the Qt version.

The other change I made was to add a default exception handler to get_window_title (again, GTK version).  This is assuredly not the best way to do it, but without it parts of AutoKey were crashing due to the unhandled exception I was generating.  I think I was getting an X11 BAD_ATOM exception, but that was last week so my memory is foggy.  This default handler simply catches any exception, and silently continues if the exception isn't already explicitly listed (this is why I think there's a better way to do it, I just don't know what it is).

And here is my first github pull request!

Trey