### PR TITLE
Returning result of wait events

### DIFF
--- a/src/lib/iomediator00.py
+++ b/src/lib/iomediator00.py
@@ -263,7 +263,7 @@ class Waiter:
             self.modifiers.sort()
 
     def wait(self):
-        self.event.wait(self.timeOut)
+        return self.event.wait(self.timeOut)
         
     def handle_keypress(self, rawKey, modifiers, key, *args):
         if rawKey == self.rawKey and modifiers == self.modifiers:

--- a/src/lib/scripting.py
+++ b/src/lib/scripting.py
@@ -111,7 +111,7 @@ class Keyboard:
         @param timeOut: maximum time, in seconds, to wait for the keypress to occur
         """
         w = iomediator.Waiter(key, modifiers, None, timeOut)
-        w.wait()
+        return w.wait()
         
 
 class Mouse:


### PR DESCRIPTION
I wanted to watch for a specific key combination for a period of time and do sth if pressed.
Current version does not support that, but Phyton's threading.Event() class already returns that information.

I added "return" statements to propagate that result up to keyboard.wait_for_key() method. I tried and it works now.

And here goes my first ever pull request on GitHub...
