### PR TITLE
Remove import warnings

### DIFF
--- a/src/lib/gtkui/configwindow.py
+++ b/src/lib/gtkui/configwindow.py
@@ -17,6 +17,10 @@
 
 import logging, sys, os, webbrowser, re, time
 #import gtk, Gtk.glade, gtksourceview2, pango
+
+from gi import require_version
+require_version('GtkSource', '3.0')
+
 from gi.repository import Gtk, Pango, GtkSource, Gdk, Gio
 
 #import gettext

--- a/src/lib/gtkui/notifier.py
+++ b/src/lib/gtkui/notifier.py
@@ -16,6 +16,10 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>..
 
 #import pynotify, gtk, gettext
+from gi import require_version
+require_version('Gtk', '3.0')
+require_version('Notify', '0.7')
+
 from gi.repository import Gtk, Gdk, Notify
 import gettext
 


### PR DESCRIPTION
Removes warnings related to importing by using gi.require_version.